### PR TITLE
WIP: Label Encoder

### DIFF
--- a/include/preprocessing.hpp
+++ b/include/preprocessing.hpp
@@ -25,4 +25,16 @@ Matrix Preprocessing::normalize(Matrix mat, std::string dim) {
     return result;
 }
 
+class LabelEncoder {
+  private:
+    Matrix labels;
+
+  public:
+    void fit(Matrix Y);
+    Matrix fit_transform(Matrix Y);
+    Matrix get_params();
+    void set_params();
+    Matrix transform(Matrix Y);
+}
+
 #endif /* _preprocessing_h_ */


### PR DESCRIPTION
This label encoder will be used in KNN for transforming string labels to double. 
For more information, refer: [sklearn: LabelEncoder](https://scikit-learn.org/stable/modules/generated/sklearn.preprocessing.LabelEncoder.html)